### PR TITLE
ICACHE_RAM_ATTR attribute fix for esp8266 and esp32 boards

### DIFF
--- a/MHZ19PWM.cpp
+++ b/MHZ19PWM.cpp
@@ -2,7 +2,11 @@
 
 MHZ19PWM * MHZ19PWM::instance = nullptr;
 
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+void ICACHE_RAM_ATTR MHZ19PWM::isr()
+#else
 void MHZ19PWM::isr()
+#endif
 {
 	if (MHZ19PWM::instance)
 		MHZ19PWM::instance->isrInternal();
@@ -96,7 +100,11 @@ void MHZ19PWM::waitForData()
 	while (!isDataReady()) {}
 }
 
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+void ICACHE_RAM_ATTR MHZ19PWM::isrInternal()
+#else
 void MHZ19PWM::isrInternal()
+#endif
 {
 	int value = digitalRead(_pin);
 	unsigned long ms = micros();

--- a/MHZ19PWM.cpp
+++ b/MHZ19PWM.cpp
@@ -2,7 +2,7 @@
 
 MHZ19PWM * MHZ19PWM::instance = nullptr;
 
-void ISR_ATTR MHZ19PWM::isr()
+void MHZ19PWM::isr()
 {
 	if (MHZ19PWM::instance)
 		MHZ19PWM::instance->isrInternal();
@@ -99,7 +99,7 @@ void MHZ19PWM::waitForData()
 	}
 }
 
-void ISR_ATTR MHZ19PWM::isrInternal()
+void MHZ19PWM::isrInternal()
 {
 	int value = digitalRead(_pin);
 	unsigned long ms = micros();

--- a/MHZ19PWM.cpp
+++ b/MHZ19PWM.cpp
@@ -2,7 +2,7 @@
 
 MHZ19PWM * MHZ19PWM::instance = nullptr;
 
-void ISR_FN_ATTR MHZ19PWM::isr()
+void ISR_ATTR MHZ19PWM::isr()
 {
 	if (MHZ19PWM::instance)
 		MHZ19PWM::instance->isrInternal();
@@ -99,7 +99,7 @@ void MHZ19PWM::waitForData()
 	}
 }
 
-void ISR_FN_ATTR MHZ19PWM::isrInternal()
+void ISR_ATTR MHZ19PWM::isrInternal()
 {
 	int value = digitalRead(_pin);
 	unsigned long ms = micros();

--- a/MHZ19PWM.cpp
+++ b/MHZ19PWM.cpp
@@ -2,11 +2,7 @@
 
 MHZ19PWM * MHZ19PWM::instance = nullptr;
 
-#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
-void ICACHE_RAM_ATTR MHZ19PWM::isr()
-#else
-void MHZ19PWM::isr()
-#endif
+void ISR_FN_ATTR MHZ19PWM::isr()
 {
 	if (MHZ19PWM::instance)
 		MHZ19PWM::instance->isrInternal();
@@ -103,11 +99,7 @@ void MHZ19PWM::waitForData()
 	}
 }
 
-#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
-void ICACHE_RAM_ATTR MHZ19PWM::isrInternal()
-#else
-void MHZ19PWM::isrInternal()
-#endif
+void ISR_FN_ATTR MHZ19PWM::isrInternal()
 {
 	int value = digitalRead(_pin);
 	unsigned long ms = micros();

--- a/MHZ19PWM.cpp
+++ b/MHZ19PWM.cpp
@@ -97,7 +97,10 @@ void MHZ19PWM::stop()
 
 void MHZ19PWM::waitForData()
 {
-	while (!isDataReady()) {}
+	while (!isDataReady())
+	{
+		yield();
+	}
 }
 
 #if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)

--- a/MHZ19PWM.h
+++ b/MHZ19PWM.h
@@ -2,11 +2,11 @@
 #include <Arduino.h>
 
 #if defined(ARDUINO_ARCH_ESP8266)
-#define ISR_FN_ATTR ICACHE_RAM_ATTR
+#define ISR_ATTR ICACHE_RAM_ATTR
 #elif defined(ARDUINO_ARCH_ESP32)
-#define ISR_FN_ATTR IRAM_ATTR
+#define ISR_ATTR IRAM_ATTR
 #else
-#define ISR_FN_ATTR
+#define ISR_ATTR
 #endif
 
 enum MHZ_MODE {
@@ -19,7 +19,6 @@ class MHZ19PWM
 {
 public:
 	static MHZ19PWM * instance;
-
 	static void isr();
 
 	MHZ19PWM(byte pin, MHZ_MODE mode = MHZ_DELAYED_MODE);
@@ -43,7 +42,5 @@ private:
 	void start();
 	void stop();
 	void waitForData();
-
 	void isrInternal();
-
 };

--- a/MHZ19PWM.h
+++ b/MHZ19PWM.h
@@ -11,7 +11,12 @@ class MHZ19PWM
 {
 public:
 	static MHZ19PWM * instance;
+
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	static ICACHE_RAM_ATTR void isr();
+#else 
 	static void isr();
+#endif
 
 	MHZ19PWM(byte pin, MHZ_MODE mode = MHZ_DELAYED_MODE);
 	~MHZ19PWM();
@@ -34,5 +39,11 @@ private:
 	void start();
 	void stop();
 	void waitForData();
+
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	void ICACHE_RAM_ATTR isrInternal();
+#else
 	void isrInternal();
+#endif
+
 };

--- a/MHZ19PWM.h
+++ b/MHZ19PWM.h
@@ -19,7 +19,7 @@ class MHZ19PWM
 {
 public:
 	static MHZ19PWM * instance;
-	static void isr();
+	static void ISR_ATTR isr();
 
 	MHZ19PWM(byte pin, MHZ_MODE mode = MHZ_DELAYED_MODE);
 	~MHZ19PWM();
@@ -42,5 +42,5 @@ private:
 	void start();
 	void stop();
 	void waitForData();
-	void isrInternal();
+	void ISR_ATTR isrInternal();
 };

--- a/MHZ19PWM.h
+++ b/MHZ19PWM.h
@@ -1,6 +1,14 @@
 #pragma once
 #include <Arduino.h>
 
+#if defined(ARDUINO_ARCH_ESP8266)
+#define ISR_FN_ATTR ICACHE_RAM_ATTR
+#elif defined(ARDUINO_ARCH_ESP32)
+#define ISR_FN_ATTR IRAM_ATTR
+#else
+#define ISR_FN_ATTR
+#endif
+
 enum MHZ_MODE {
 	MHZ_CONTINUOUS_MODE,
 	MHZ_DELAYED_MODE,
@@ -12,11 +20,7 @@ class MHZ19PWM
 public:
 	static MHZ19PWM * instance;
 
-#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
-	static ICACHE_RAM_ATTR void isr();
-#else 
 	static void isr();
-#endif
 
 	MHZ19PWM(byte pin, MHZ_MODE mode = MHZ_DELAYED_MODE);
 	~MHZ19PWM();
@@ -40,10 +44,6 @@ private:
 	void stop();
 	void waitForData();
 
-#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
-	void ICACHE_RAM_ATTR isrInternal();
-#else
 	void isrInternal();
-#endif
 
 };


### PR DESCRIPTION
Added ICACHE_RAM_ATTR attribute to isr functions for esp8266 and esp32 boards.
Added yield() to waitForData function to avoid WDT reset on esp boards.
Fixes issue #9